### PR TITLE
Fix "year" variable missing from root of output climate file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Bad hyperlink for release in CHANGELOG.
-- Missing "year" variable from root of output climate data file.
+- Missing "year" variable from root of output climate data file ([PR #6](https://github.com/fact-sealevel/fair-temperature/pull/6), [@brews](https://github.com/brews)).
 
 
 ## [0.2.0] - 2025-10-17

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Bad hyperlink for release in CHANGELOG.
-
+- Missing "year" variable from root of output climate data file.
 
 
 ## [0.2.0] - 2025-10-17

--- a/src/fair_temperature/fair_temperature_project.py
+++ b/src/fair_temperature/fair_temperature_project.py
@@ -317,6 +317,8 @@ def fair_project_temperature(
             },
         },
     )
+    yearsds = xr.Dataset({"year": proj_years})
+    yearsds.to_netcdf(out_climate_file, mode="a")
 
     # Done
     return None

--- a/src/fair_temperature/fair_temperature_project.py
+++ b/src/fair_temperature/fair_temperature_project.py
@@ -317,6 +317,9 @@ def fair_project_temperature(
             },
         },
     )
+
+    # Adds "year" variable to root of hierarchy in output NetCDF4 file. Some
+    # modules depend on this behavior in the original FACTS1.
     yearsds = xr.Dataset({"year": proj_years})
     yearsds.to_netcdf(out_climate_file, mode="a")
 


### PR DESCRIPTION
The fair/temperature module in facts1 apparently put a "year" variable in the root of its output climate NetCDF4 file. This has been missing from the containerized version. This fixes it, putting the variable back in the file.

Found that this variable was missing while trying to containerize emulandice2 in https://github.com/fact-sealevel/emulandice2/pull/1